### PR TITLE
Remove forwarder (-f) and mirror options (-m)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang
+
+RUN go get -u github.com/Zilliqa/goduplicator
+
+CMD ["goduplicator"]

--- a/main.go
+++ b/main.go
@@ -110,6 +110,22 @@ func (l *mirrorList) Set(value string) error {
 	return nil
 }
 
+func reportDifference(new []string, old []string, oSet *set) (nSet *set) {
+	nSet = NewSet()
+	for _, n := range new {
+		nSet.Add(n)
+		if !oSet.Contains(n) {
+			log.Printf("mirror address added '%v'", n)	
+		}
+	}
+	for _, o := range old {
+		if !nSet.Contains(o) {
+			log.Printf("mirror address removed '%v'", o)
+		}
+	}
+	return
+}
+
 func main() {
 	var (
 		connectTimeout   time.Duration
@@ -127,7 +143,7 @@ func main() {
 	flag.DurationVar(&delay, "d", 1*time.Second, "delay connecting to mirror after unsuccessful attempt")
 	flag.DurationVar(&writeTimeout, "wt", 20*time.Millisecond, "mirror write timeout")
 	flag.DurationVar(&mirrorCloseDelay, "mt", 0, "mirror conn close delay")
-	flag.StringVar(&seedurl, "s", "", "seed url to check level2lookupips")
+	flag.StringVar(&seedurl, "s", "", "URL for downstream IP list text file (e.g. http://a.com/ip.txt")
 
 	flag.Parse()
 	if listenAddress == "" {
@@ -140,7 +156,7 @@ func main() {
 		log.Fatalf("error while listening: %s", err)
 	}
 
-	fmt.Println(seedurl)
+	log.Println("URL is", seedurl)
 	if seedurl == "" {
 		flag.Usage()
 		return
@@ -154,6 +170,8 @@ func main() {
 	// routine that gets the latest updates of mirror address every 10 sec
 	// We always replace all existing addresses with new ones read.
 	go func() {
+		addressStore := NewSet()
+
 		for {
 			response, err := http.Get(seedurl)
 			if err != nil {
@@ -165,8 +183,11 @@ func main() {
 					if err != nil {
 							log.Fatal(err)
 					}
+					oldAddresses := mirrorAddresses
+					newAddresses := strings.Split(string(contents),"\n")
+					addressStore = reportDifference(newAddresses, oldAddresses, addressStore)
 					lock2.Lock()
-					mirrorAddresses = strings.Split(string(contents),"\n")
+					mirrorAddresses = newAddresses
 					lock2.Unlock()
 				} else {
 					log.Printf("May be seedurl: %s is not available at the moment", seedurl)
@@ -193,7 +214,7 @@ func main() {
 			log.Fatalf("Error while accepting: %s", err)
 		}
 
-		log.Printf("accepted connection (%s <-> %s)", c.RemoteAddr(), c.LocalAddr())
+		log.Printf("accepted upstream connection (%s <-> %s)", c.RemoteAddr(), c.LocalAddr())
 
 		go func(c net.Conn) {
 			defer c.Close()
@@ -206,7 +227,7 @@ func main() {
 				n, err1 = c.Read(tmp)
 				if err1 != nil {
 					if err1 != io.EOF {
-						fmt.Println("read error:", err1)
+						log.Println("read error:", err1)
 						}
 					break
 				}
@@ -241,6 +262,7 @@ func main() {
 			localMirrorAddresses = make(mirrorList, len(mirrorAddresses))
 			copy(localMirrorAddresses, mirrorAddresses)
 			lock2.RUnlock()
+			
 			for _, addr := range localMirrorAddresses {
 				if addr == "" {
 					continue


### PR DESCRIPTION
The `-f` and `-m` options are not in use. Removing them for code tidiness.

This PR also fixes a race condition by making a copy of `mirrorAddresses` to `localMirrorAddresses`

TODOs:
- [x] Dockerfile
- [x] more logs